### PR TITLE
Obey general token limits

### DIFF
--- a/app/lib/.server/llm/constants.ts
+++ b/app/lib/.server/llm/constants.ts
@@ -1,5 +1,5 @@
 // see https://docs.anthropic.com/en/docs/about-claude/models
-export const MAX_TOKENS = 8192;
+export const MAX_TOKENS = 8000;
 
 // limits the number of model responses that can be returned in a single request
 export const MAX_RESPONSE_SEGMENTS = 2;


### PR DESCRIPTION
- Changed max tokens from 8120 -> 8000
- Works with some models (i.e., Grok) with limits like this
- No effect otherwise, single-response limit only